### PR TITLE
Update machina.js license info in package.json

### DIFF
--- a/ajax/libs/machina.js/package.json
+++ b/ajax/libs/machina.js/package.json
@@ -21,13 +21,7 @@
     "machina.js",
     "machinajs"
   ],
-  "licenses": [
-    "MIT",
-    {
-      "type": "GPL",
-      "url": "http://opensource.org/licenses/GPL-2.0"
-    }
-  ],
+  "license": "MIT",
   "npmName": "machina",
   "npmFileMap": [
     {


### PR DESCRIPTION
Update it because the license machina.js used changed, cc #11931
Ref: https://github.com/ifandelse/machina.js/blob/master/LICENSE#L1